### PR TITLE
Fix Version Already Used Error

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "BlazeFL"
 copyright = "2024, kitsuya0828"
 author = "kitsuya0828"
-release = "0.1.0rc2"
+release = "0.1.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blazefl"
-version = "0.1.0"
+version = "0.1.1"
 description = "A blazing-fast and lightweight simulation framework for Federated Learning."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "blazefl"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
https://github.com/kitsuya0828/BlazeFL/actions/runs/12415526472/job/34662090311

> Uploading blazefl-0.1.0-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         This filename has already been used, use a different version. See      
         https://pypi.org/help/#file-name-reuse for more information.    

> PyPI does not allow for a filename to be reused, even once a project has been deleted and recreated.

Since I initially used v0.1.0 on PyPI for testing purposes, I have no choice but to increase the version number.