### PR TITLE
Take Device as an Argument in Each Client Process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blazefl"
-version = "0.1.2"
+version = "1.0.0"
 description = "A blazing-fast and lightweight simulation framework for Federated Learning."
 readme = "README.md"
 authors = [

--- a/tests/test_core/test_client_trainer.py
+++ b/tests/test_core/test_client_trainer.py
@@ -34,8 +34,9 @@ class DummyParallelClientTrainer(
         return DiskSharedData(cid=cid, payload=payload)
 
     @staticmethod
-    def process_client(path: Path) -> Path:
+    def process_client(path: Path, device: str) -> Path:
         data = torch.load(path, weights_only=False)
+        _ = device
         downlink_package = data.payload
 
         dummy_uplink_package = UplinkPackage(
@@ -52,7 +53,7 @@ def test_parallel_client_trainer(
     tmp_path: Path, num_parallels: int, cid_list: list[int]
 ) -> None:
     trainer = DummyParallelClientTrainer(
-        num_parallels=num_parallels, share_dir=tmp_path
+        num_parallels=num_parallels, share_dir=tmp_path, device="cpu"
     )
 
     dummy_payload = DownlinkPackage(message="<server_to_client>")

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "blazefl"
-version = "0.1.2"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## WHAT
Updated the `process_client()` method to take `device` as an argument.

## WHY
To ensure that the appropriate device is used for each client process.