### PR TITLE
chore: update example to use blazefl's thread-pool client trainer

### DIFF
--- a/examples/experimental-freethreaded/config/config.yaml
+++ b/examples/experimental-freethreaded/config/config.yaml
@@ -15,3 +15,4 @@ dataset_split_dir: /tmp/experimental-freethreaded/split
 share_dir: /tmp/experimental-freethreaded/share
 state_dir: /tmp/experimental-freethreaded/state
 execution_mode: multi-thread
+ipc_mode: storage

--- a/examples/experimental-freethreaded/main.py
+++ b/examples/experimental-freethreaded/main.py
@@ -100,7 +100,7 @@ def main(cfg: DictConfig):
         | None
     ) = None
     match cfg.execution_mode:
-        case "serial":
+        case "single-thread":
             trainer = FedAvgBaseClientTrainer(
                 model_selector=model_selector,
                 model_name=cfg.model_name,
@@ -146,9 +146,7 @@ def main(cfg: DictConfig):
     try:
         pipeline.main()
     except KeyboardInterrupt:
-        logging.info("KeyboardInterrupt: Stopping the pipeline.")
-    except Exception as e:
-        logging.exception(f"An error occurred: {e}")
+        logging.info("KeyboardInterrupt")
 
 
 if __name__ == "__main__":

--- a/examples/experimental-freethreaded/pyproject.toml
+++ b/examples/experimental-freethreaded/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "blazefl>=2.0.0dev4",
+    "blazefl>=2.0.0dev5",
     "hydra-core>=1.3.2",
     "torch>=2.7.1",
     "torchvision>=0.22.1",

--- a/examples/experimental-freethreaded/pyproject.toml
+++ b/examples/experimental-freethreaded/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "blazefl>=2.0.0dev5",
+    "blazefl>=2.0.0dev6",
     "hydra-core>=1.3.2",
     "torch>=2.7.1",
     "torchvision>=0.22.1",

--- a/examples/experimental-freethreaded/pyproject.toml
+++ b/examples/experimental-freethreaded/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "blazefl>=2.0.0dev2",
+    "blazefl>=2.0.0dev4",
     "hydra-core>=1.3.2",
     "torch>=2.7.1",
     "torchvision>=0.22.1",

--- a/examples/experimental-freethreaded/uv.lock
+++ b/examples/experimental-freethreaded/uv.lock
@@ -10,16 +10,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d
 
 [[package]]
 name = "blazefl"
-version = "2.0.0.dev4"
+version = "2.0.0.dev5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/7a/8bc9d80ddc5e3e7045ce94e2083004cbc8494407cf3a6377d96897a53673/blazefl-2.0.0.dev4.tar.gz", hash = "sha256:3390196cd2e55714bcd2f7d0cf5a68dd4c1725fc064ceab5e149a5ab8e5f150d", size = 614624, upload_time = "2025-06-14T11:29:20.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/bd/0d69d4614277422c29b0290dd4dd8393d92f50c331a36f9412cbd8424d25/blazefl-2.0.0.dev5.tar.gz", hash = "sha256:6ad22b42a40e1a1eff618d024806184031e861fe060a6a1454889fe56f2dae94", size = 615112, upload_time = "2025-06-15T02:07:04.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/0b/3f9fc7ac7e6ccf39d0ce49f012051c120a35853855621679e68f7cc60a62/blazefl-2.0.0.dev4-py3-none-any.whl", hash = "sha256:3d83f6d8f47a3e90aceea2f8048b58c4550d0729ec1be10edf8c6f4a3308fe9a", size = 25738, upload_time = "2025-06-14T11:29:19.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/9c/56b7ca8803f51aa016eeae93205a2e2552e4d6e75c205a8f64af3a9b488b/blazefl-2.0.0.dev5-py3-none-any.whl", hash = "sha256:e6aef8f7bc882359733d63f1ed24dc5560901666c97e9256e50351da2a192e4c", size = 26138, upload_time = "2025-06-15T02:07:02.79Z" },
 ]
 
 [[package]]
@@ -50,7 +50,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blazefl", specifier = ">=2.0.0.dev4" },
+    { name = "blazefl", specifier = ">=2.0.0.dev5" },
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "torch", specifier = ">=2.7.1" },
     { name = "torchvision", specifier = ">=0.22.1" },

--- a/examples/experimental-freethreaded/uv.lock
+++ b/examples/experimental-freethreaded/uv.lock
@@ -10,16 +10,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d
 
 [[package]]
 name = "blazefl"
-version = "2.0.0.dev2"
+version = "2.0.0.dev4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/92/3f668d7259a81d13d5d2e6089d8022629a09058ddbcae33f5873d3871656/blazefl-2.0.0.dev2.tar.gz", hash = "sha256:28a3e09d6f6cec8d8e8bb4da90adaa0c795980c74f9d4ce65024ba762726b595", size = 613563, upload_time = "2025-06-10T09:24:08.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/7a/8bc9d80ddc5e3e7045ce94e2083004cbc8494407cf3a6377d96897a53673/blazefl-2.0.0.dev4.tar.gz", hash = "sha256:3390196cd2e55714bcd2f7d0cf5a68dd4c1725fc064ceab5e149a5ab8e5f150d", size = 614624, upload_time = "2025-06-14T11:29:20.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/7c/841c8b9d22caaefc1dcc167076292fd1479309b3e11eb6fc1b24141792a8/blazefl-2.0.0.dev2-py3-none-any.whl", hash = "sha256:88639018166dafa79fde59aa5575bfb7277bf9e0e4497f22a59e9c7ec34efa4b", size = 23999, upload_time = "2025-06-10T09:24:07.553Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0b/3f9fc7ac7e6ccf39d0ce49f012051c120a35853855621679e68f7cc60a62/blazefl-2.0.0.dev4-py3-none-any.whl", hash = "sha256:3d83f6d8f47a3e90aceea2f8048b58c4550d0729ec1be10edf8c6f4a3308fe9a", size = 25738, upload_time = "2025-06-14T11:29:19.741Z" },
 ]
 
 [[package]]
@@ -50,7 +50,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blazefl", specifier = ">=2.0.0.dev2" },
+    { name = "blazefl", specifier = ">=2.0.0.dev4" },
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "torch", specifier = ">=2.7.1" },
     { name = "torchvision", specifier = ">=0.22.1" },

--- a/examples/experimental-freethreaded/uv.lock
+++ b/examples/experimental-freethreaded/uv.lock
@@ -10,16 +10,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d
 
 [[package]]
 name = "blazefl"
-version = "2.0.0.dev5"
+version = "2.0.0.dev6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/bd/0d69d4614277422c29b0290dd4dd8393d92f50c331a36f9412cbd8424d25/blazefl-2.0.0.dev5.tar.gz", hash = "sha256:6ad22b42a40e1a1eff618d024806184031e861fe060a6a1454889fe56f2dae94", size = 615112, upload_time = "2025-06-15T02:07:04.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/76/d247942d051447dc1c6dbc25b2d55b4cdf146cc0ebd3594c0c33628f465c/blazefl-2.0.0.dev6.tar.gz", hash = "sha256:d4875f03872917dfd99b3a70ac2c6efc3483ee0e42e484d7328e0810fe5141b9", size = 615380, upload_time = "2025-06-16T16:26:50.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/9c/56b7ca8803f51aa016eeae93205a2e2552e4d6e75c205a8f64af3a9b488b/blazefl-2.0.0.dev5-py3-none-any.whl", hash = "sha256:e6aef8f7bc882359733d63f1ed24dc5560901666c97e9256e50351da2a192e4c", size = 26138, upload_time = "2025-06-15T02:07:02.79Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/30/eba32caaed89d04c925f676d48fb50bad7bed3ce2c86c6ebcaf2eb92aff1/blazefl-2.0.0.dev6-py3-none-any.whl", hash = "sha256:e38c3739be9ef2bc7bb8ba213da3319e4be8f9ea9f27ecd661cbc70c0cedd655", size = 26215, upload_time = "2025-06-16T16:26:49.512Z" },
 ]
 
 [[package]]
@@ -50,7 +50,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blazefl", specifier = ">=2.0.0.dev5" },
+    { name = "blazefl", specifier = ">=2.0.0.dev6" },
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "torch", specifier = ">=2.7.1" },
     { name = "torchvision", specifier = ">=0.22.1" },


### PR DESCRIPTION
## WHAT

This PR updates the experimental free-threaded example to use BlazeFL’s new `ThreadPoolClientTrainer`, applying the necessary API renames.

## WHY

To ensure the example stays compatible with the latest development release of BlazeFL.