### PR TITLE
feat: move tqdm to optional dependencies

### DIFF
--- a/docs/imgs/benchmark_cnn.svg
+++ b/docs/imgs/benchmark_cnn.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-06-27T16:58:39.448699</dc:date>
+    <dc:date>2025-06-28T06:53:05.125011</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 113.577465 384.48 
 L 113.577465 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -72,7 +72,7 @@ z
      <g id="line2d_3">
       <path d="M 145.014085 384.48 
 L 145.014085 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
@@ -126,7 +126,7 @@ z
      <g id="line2d_5">
       <path d="M 207.887324 384.48 
 L 207.887324 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
@@ -169,7 +169,7 @@ z
      <g id="line2d_7">
       <path d="M 270.760563 384.48 
 L 270.760563 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
@@ -235,7 +235,7 @@ z
      <g id="line2d_9">
       <path d="M 333.633803 384.48 
 L 333.633803 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
@@ -324,7 +324,7 @@ z
      <g id="line2d_11">
       <path d="M 396.507042 384.48 
 L 396.507042 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
@@ -378,7 +378,7 @@ z
      <g id="line2d_13">
       <path d="M 459.380282 384.48 
 L 459.380282 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
@@ -393,7 +393,7 @@ L 459.380282 51.84
      <g id="line2d_15">
       <path d="M 522.253521 384.48 
 L 522.253521 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
@@ -408,7 +408,7 @@ L 522.253521 51.84
      <g id="line2d_17">
       <path d="M 585.126761 384.48 
 L 585.126761 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_18"/>
      <g id="text_9">
@@ -423,7 +423,7 @@ L 585.126761 51.84
      <g id="line2d_19">
       <path d="M 648 384.48 
 L 648 51.84 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_20"/>
      <g id="text_10">
@@ -724,7 +724,7 @@ z
      <g id="line2d_21">
       <path d="M 90 352.034846 
 L 648 352.034846 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_22"/>
      <g id="text_12">
@@ -738,7 +738,7 @@ L 648 352.034846
      <g id="line2d_23">
       <path d="M 90 301.068616 
 L 648 301.068616 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_24"/>
      <g id="text_13">
@@ -752,7 +752,7 @@ L 648 301.068616
      <g id="line2d_25">
       <path d="M 90 250.102386 
 L 648 250.102386 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_26"/>
      <g id="text_14">
@@ -819,7 +819,7 @@ z
      <g id="line2d_27">
       <path d="M 90 199.136156 
 L 648 199.136156 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_28"/>
      <g id="text_15">
@@ -833,7 +833,7 @@ L 648 199.136156
      <g id="line2d_29">
       <path d="M 90 148.169927 
 L 648 148.169927 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_30"/>
      <g id="text_16">
@@ -889,7 +889,7 @@ z
      <g id="line2d_31">
       <path d="M 90 97.203697 
 L 648 97.203697 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke-dasharray: 1.85,0.8; stroke-dashoffset: 0; stroke: #cccccc; stroke-width: 0.5"/>
      </g>
      <g id="line2d_32"/>
      <g id="text_17">
@@ -1360,9 +1360,9 @@ L 396.507042 192.106332
 L 459.380282 184.574377 
 L 522.253521 186.123502 
 L 585.126761 214.237262 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: round"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="med767c9431" d="M 0 3 
+     <path id="m48d6e27ffb" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1374,16 +1374,16 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pc566ce173d)">
-     <use xlink:href="#med767c9431" x="113.577465" y="369.36" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="145.014085" y="340.079804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="207.887324" y="295.70375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="270.760563" y="254.555746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="333.633803" y="227.255456" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="396.507042" y="192.106332" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="459.380282" y="184.574377" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="522.253521" y="186.123502" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#med767c9431" x="585.126761" y="214.237262" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p123f73ffd6)">
+     <use xlink:href="#m48d6e27ffb" x="113.577465" y="369.36" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="145.014085" y="340.079804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="207.887324" y="295.70375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="270.760563" y="254.555746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="333.633803" y="227.255456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="396.507042" y="192.106332" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="459.380282" y="184.574377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="522.253521" y="186.123502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m48d6e27ffb" x="585.126761" y="214.237262" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_34">
@@ -1396,25 +1396,25 @@ L 396.507042 269.465102
 L 459.380282 275.585501 
 L 522.253521 288.470222 
 L 585.126761 299.340947 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: round"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="me596d03dcc" d="M -3 3 
+     <path id="m0c46ed39f3" d="M -3 3 
 L 3 3 
 L 3 -3 
 L -3 -3 
 z
 " style="stroke: #ff7f0e; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc566ce173d)">
-     <use xlink:href="#me596d03dcc" x="113.577465" y="362.064345" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="145.014085" y="329.31496" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="207.887324" y="295.325942" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="270.760563" y="273.972646" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="333.633803" y="268.288574" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="396.507042" y="269.465102" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="459.380282" y="275.585501" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="522.253521" y="288.470222" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#me596d03dcc" x="585.126761" y="299.340947" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+    <g clip-path="url(#p123f73ffd6)">
+     <use xlink:href="#m0c46ed39f3" x="113.577465" y="362.064345" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="145.014085" y="329.31496" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="207.887324" y="295.325942" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="270.760563" y="273.972646" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="333.633803" y="268.288574" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="396.507042" y="269.465102" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="459.380282" y="275.585501" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="522.253521" y="288.470222" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c46ed39f3" x="585.126761" y="299.340947" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_35">
@@ -1427,24 +1427,24 @@ L 396.507042 106.110417
 L 459.380282 74.18669 
 L 522.253521 66.96 
 L 585.126761 128.743337 
-" clip-path="url(#pc566ce173d)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: round"/>
+" clip-path="url(#p123f73ffd6)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: round"/>
     <defs>
-     <path id="m932d8c90cd" d="M 0 -3 
+     <path id="m6c955c3fb7" d="M 0 -3 
 L -3 3 
 L 3 3 
 z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc566ce173d)">
-     <use xlink:href="#m932d8c90cd" x="113.577465" y="359.378055" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="145.014085" y="321.455108" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="207.887324" y="257.383276" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="270.760563" y="208.225675" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="333.633803" y="160.304743" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="396.507042" y="106.110417" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="459.380282" y="74.18669" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="522.253521" y="66.96" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m932d8c90cd" x="585.126761" y="128.743337" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    <g clip-path="url(#p123f73ffd6)">
+     <use xlink:href="#m6c955c3fb7" x="113.577465" y="359.378055" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="145.014085" y="321.455108" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="207.887324" y="257.383276" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="270.760563" y="208.225675" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="333.633803" y="160.304743" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="396.507042" y="106.110417" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="459.380282" y="74.18669" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="522.253521" y="66.96" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c955c3fb7" x="585.126761" y="128.743337" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1533,17 +1533,17 @@ z
    </g>
    <g id="legend_1">
     <g id="line2d_36">
-     <path d="M 249.12 306.68625 
-L 267.12 306.68625 
-L 285.12 306.68625 
+     <path d="M 245.105156 306.68625 
+L 263.105156 306.68625 
+L 281.105156 306.68625 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#med767c9431" x="267.12" y="306.68625" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m48d6e27ffb" x="263.105156" y="306.68625" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_20">
      <!-- Flower -->
-     <g style="fill: #262626" transform="translate(299.52 312.98625) scale(0.18 -0.18)">
+     <g style="fill: #262626" transform="translate(295.505156 312.98625) scale(0.18 -0.18)">
       <defs>
        <path id="LiberationSans-46" d="M 1122 3916 
 L 1122 2278 
@@ -1602,17 +1602,17 @@ z
      </g>
     </g>
     <g id="line2d_37">
-     <path d="M 249.12 332.465625 
-L 267.12 332.465625 
-L 285.12 332.465625 
+     <path d="M 245.105156 332.465625 
+L 263.105156 332.465625 
+L 281.105156 332.465625 
 " style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#me596d03dcc" x="267.12" y="332.465625" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+      <use xlink:href="#m0c46ed39f3" x="263.105156" y="332.465625" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
      <!-- BlazeFL (multi-process) -->
-     <g style="fill: #262626" transform="translate(299.52 338.765625) scale(0.18 -0.18)">
+     <g style="fill: #262626" transform="translate(295.505156 338.765625) scale(0.18 -0.18)">
       <defs>
        <path id="LiberationSans-7a" d="M 153 0 
 L 153 428 
@@ -1795,17 +1795,17 @@ z
      </g>
     </g>
     <g id="line2d_38">
-     <path d="M 249.12 358.245 
-L 267.12 358.245 
-L 285.12 358.245 
+     <path d="M 245.105156 358.245 
+L 263.105156 358.245 
+L 281.105156 358.245 
 " style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m932d8c90cd" x="267.12" y="358.245" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+      <use xlink:href="#m6c955c3fb7" x="263.105156" y="358.245" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
-     <!-- BlazeFL (multi-thread) -->
-     <g style="fill: #262626" transform="translate(299.52 364.545) scale(0.18 -0.18)">
+     <!-- BlazeFL (multi-threaded) -->
+     <g style="fill: #262626" transform="translate(295.505156 364.545) scale(0.18 -0.18)">
       <use xlink:href="#LiberationSans-42"/>
       <use xlink:href="#LiberationSans-6c" transform="translate(66.699219 0)"/>
       <use xlink:href="#LiberationSans-61" transform="translate(88.916016 0)"/>
@@ -1827,14 +1827,16 @@ L 285.12 358.245
       <use xlink:href="#LiberationSans-65" transform="translate(785.3125 0)"/>
       <use xlink:href="#LiberationSans-61" transform="translate(840.927734 0)"/>
       <use xlink:href="#LiberationSans-64" transform="translate(896.542969 0)"/>
-      <use xlink:href="#LiberationSans-29" transform="translate(952.158203 0)"/>
+      <use xlink:href="#LiberationSans-65" transform="translate(952.158203 0)"/>
+      <use xlink:href="#LiberationSans-64" transform="translate(1007.773438 0)"/>
+      <use xlink:href="#LiberationSans-29" transform="translate(1063.388672 0)"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc566ce173d">
+  <clipPath id="p123f73ffd6">
    <rect x="90" y="51.84" width="558" height="332.64"/>
   </clipPath>
  </defs>

--- a/examples/quickstart-fedavg/main.py
+++ b/examples/quickstart-fedavg/main.py
@@ -107,6 +107,17 @@ def main(cfg: DictConfig):
         | None
     ) = None
     match cfg.execution_mode:
+        case "single-threaded":
+            trainer = FedAvgBaseClientTrainer(
+                model_selector=model_selector,
+                model_name=cfg.model_name,
+                dataset=dataset,
+                device=device,
+                num_clients=cfg.num_clients,
+                epochs=cfg.epochs,
+                lr=cfg.lr,
+                batch_size=cfg.batch_size,
+            )
         case "multi-process":
             trainer = FedAvgProcessPoolClientTrainer(
                 model_selector=model_selector,
@@ -123,18 +134,7 @@ def main(cfg: DictConfig):
                 num_parallels=cfg.num_parallels,
                 ipc_mode=cfg.ipc_mode,
             )
-        case "single-thread":
-            trainer = FedAvgBaseClientTrainer(
-                model_selector=model_selector,
-                model_name=cfg.model_name,
-                dataset=dataset,
-                device=device,
-                num_clients=cfg.num_clients,
-                epochs=cfg.epochs,
-                lr=cfg.lr,
-                batch_size=cfg.batch_size,
-            )
-        case "multi-thread":
+        case "multi-threaded":
             trainer = FedAvgThreadPoolClientTrainer(
                 model_selector=model_selector,
                 model_name=cfg.model_name,

--- a/examples/quickstart-fedavg/pyproject.toml
+++ b/examples/quickstart-fedavg/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "blazefl>=1.0.2",
+    "blazefl[contrib]>=2.0.0a1",
     "hydra-core>=1.3.2",
     "tensorboard>=2.19.0",
     "torchvision>=0.22.0",
@@ -33,4 +33,5 @@ blazefl = { workspace = true }
 dev = [
     "mypy>=1.13.0",
     "pre-commit>=4.2.0",
+    "types-tqdm>=4.67.0.20250516",
 ]

--- a/examples/step-by-step-dsfl/algorithm/dsfl.py
+++ b/examples/step-by-step-dsfl/algorithm/dsfl.py
@@ -1,8 +1,10 @@
 import random
 import threading
 from collections import defaultdict
+from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
+from multiprocessing.pool import ApplyResult
 from pathlib import Path
 
 import torch
@@ -18,6 +20,7 @@ from blazefl.utils import (
     seed_everything,
 )
 from torch.utils.data import DataLoader, Subset
+from tqdm import tqdm
 
 from dataset import DSFLPartitionedDataset, DSFLPartitionType
 from models import DSFLModelSelector
@@ -311,6 +314,12 @@ class DSFLProcessPoolClientTrainer(
 
         if self.device == "cuda":
             self.device_count = torch.cuda.device_count()
+
+    def progress_fn(
+        self,
+        it: list[ApplyResult],
+    ) -> Iterable[ApplyResult]:
+        return tqdm(it, desc="Client", leave=False)
 
     @staticmethod
     def worker(

--- a/examples/step-by-step-dsfl/pyproject.toml
+++ b/examples/step-by-step-dsfl/pyproject.toml
@@ -5,10 +5,11 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "blazefl>=1.0.2",
+    "blazefl>=2.0.0a",
     "hydra-core>=1.3.2",
     "tensorboard>=2.19.0",
     "torchvision>=0.22.0",
+    "tqdm>=4.67.1",
 ]
 
 [tool.basedpyright]
@@ -37,4 +38,5 @@ blazefl = { workspace = true }
 dev = [
     "mypy>=1.13.0",
     "pre-commit>=4.2.0",
+    "types-tqdm>=4.67.0.20250516",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blazefl"
-version = "2.0.0a1"
+version = "2.0.0a2"
 description = "A blazing-fast and lightweight simulation framework for Federated Learning."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ classifiers = [
 dependencies = [
   "numpy>=2.2.6",
   "torch>=2.5.1",
-  "tqdm>=4.67.1",
+]
+
+[project.optional-dependencies]
+contrib = [
+    "tqdm>=4.67.1",
 ]
 
 [build-system]
@@ -44,6 +48,7 @@ dev = [
     "psutil>=7.0.0",
     "pytest>=8.3.4",
     "ruff>=0.8.2",
+    "tqdm>=4.67.1",
     "types-psutil>=7.0.0.20250601",
     "types-tqdm>=4.67.0.20250516",
 ]
@@ -52,7 +57,6 @@ docs = [
     "sphinx>=8.1.3",
     "sphinx-autobuild>=2024.10.3",
 ]
-test = []
 
 [tool.ruff]
 exclude = [

--- a/src/blazefl/core/client_trainer.pyi
+++ b/src/blazefl/core/client_trainer.pyi
@@ -1,5 +1,7 @@
 import threading
 from blazefl.utils import move_tensor_to_shared_memory as move_tensor_to_shared_memory
+from collections.abc import Iterable
+from concurrent.futures import Future as Future
 from multiprocessing.pool import ApplyResult as ApplyResult
 from pathlib import Path
 from typing import Literal, Protocol, TypeVar
@@ -20,6 +22,7 @@ class ProcessPoolClientTrainer(BaseClientTrainer[UplinkPackage, DownlinkPackage]
     cache: list[UplinkPackage]
     ipc_mode: Literal['storage', 'shared_memory']
     stop_event: threading.Event
+    def progress_fn(self, it: list[ApplyResult]) -> Iterable[ApplyResult]: ...
     def get_client_config(self, cid: int) -> ClientConfig: ...
     def get_client_device(self, cid: int) -> str: ...
     @staticmethod
@@ -32,6 +35,7 @@ class ThreadPoolClientTrainer(BaseClientTrainer[UplinkPackage, DownlinkPackage],
     device_count: int
     cache: list[UplinkPackage]
     stop_event: threading.Event
+    def progress_fn(self, it: list[Future[UplinkPackage]]) -> Iterable[Future[UplinkPackage]]: ...
     def worker(self, cid: int, device: str, payload: DownlinkPackage, stop_event: threading.Event) -> UplinkPackage: ...
     def get_client_device(self, cid: int) -> str: ...
     def local_process(self, payload: DownlinkPackage, cid_list: list[int]) -> None: ...

--- a/uv.lock
+++ b/uv.lock
@@ -82,7 +82,7 @@ wheels = [
 
 [[package]]
 name = "blazefl"
-version = "2.0.0a1"
+version = "2.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -1070,12 +1070,14 @@ dependencies = [
     { name = "hydra-core" },
     { name = "tensorboard" },
     { name = "torchvision" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "types-tqdm" },
 ]
 
 [package.metadata]
@@ -1084,12 +1086,14 @@ requires-dist = [
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "tensorboard", specifier = ">=2.19.0" },
     { name = "torchvision", specifier = ">=0.22.0" },
+    { name = "tqdm", specifier = ">=4.67.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "types-tqdm", specifier = ">=4.67.0.20250516" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,10 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "torch" },
+]
+
+[package.optional-dependencies]
+contrib = [
     { name = "tqdm" },
 ]
 
@@ -97,6 +101,7 @@ dev = [
     { name = "psutil" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "tqdm" },
     { name = "types-psutil" },
     { name = "types-tqdm" },
 ]
@@ -110,8 +115,9 @@ docs = [
 requires-dist = [
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "torch", specifier = ">=2.5.1" },
-    { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "tqdm", marker = "extra == 'contrib'", specifier = ">=4.67.1" },
 ]
+provides-extras = ["contrib"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -120,6 +126,7 @@ dev = [
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.8.2" },
+    { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-psutil", specifier = ">=7.0.0.20250601" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250516" },
 ]
@@ -128,7 +135,6 @@ docs = [
     { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
     { name = "sphinx-book-theme", specifier = ">=1.1.3" },
 ]
-test = []
 
 [[package]]
 name = "certifi"
@@ -819,7 +825,7 @@ name = "quickstart-fedavg"
 version = "0.1.0"
 source = { virtual = "examples/quickstart-fedavg" }
 dependencies = [
-    { name = "blazefl" },
+    { name = "blazefl", extra = ["contrib"] },
     { name = "hydra-core" },
     { name = "tensorboard" },
     { name = "torchvision" },
@@ -829,11 +835,12 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "types-tqdm" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "blazefl", editable = "." },
+    { name = "blazefl", extras = ["contrib"], editable = "." },
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "tensorboard", specifier = ">=2.19.0" },
     { name = "torchvision", specifier = ">=0.22.0" },
@@ -843,6 +850,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "types-tqdm", specifier = ">=4.67.0.20250516" },
 ]
 
 [[package]]


### PR DESCRIPTION
## WHAT

This PR decouples progress reporting from core logic by introducing `progress_fn` hooks in `ProcessPoolClientTrainer` and `ThreadPoolClientTrainer`, moving `tqdm` into an optional `contrib` dependency.

## WHY

The primary motivation for this change is to minimize the core library's dependencies and enhance its flexibility.