### PR TITLE
chore: update urls after repository transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="https://raw.githubusercontent.com/kitsuyaazuma/blazefl/refs/heads/main/docs/imgs/logo.svg" width=600></div>
+<div align="center"><img src="https://raw.githubusercontent.com/blazefl/blazefl/refs/heads/main/docs/imgs/logo.svg" width=600></div>
 <div align="center">A blazing-fast, minimalist, and researcher-friendly simulation framework for Federated Learning</div>
 <br>
 <div align="center">
@@ -156,9 +156,9 @@ uv add blazefl
 
 | Example | Description | 
 |---------|-------------|
-| [Quickstart: FedAvg](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/quickstart-fedavg) | Learn the fundamentals of BlazeFL with a standard Federated Averaging (FedAvg) implementation, covering both **single-threaded** and **multi-process** modes. |
-| [Experimental: Multi-Threaded FedAvg](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/experimental-freethreaded) | Explore high-performance parallel training with a **multi-threaded** FedAvg, leveraging Python 3.13+'s experimental free-threading mode. | 
-| [Step-by-Step Tutorial: DS-FL](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl) | Build a custom distillation-based Federated Learning algorithm from scratch, and understand how to implement your own algorithms on the BlazeFL framework. |
+| [Quickstart: FedAvg](https://github.com/blazefl/blazefl/tree/main/examples/quickstart-fedavg) | Learn the fundamentals of BlazeFL with a standard Federated Averaging (FedAvg) implementation, covering both **single-threaded** and **multi-process** modes. |
+| [Experimental: Multi-Threaded FedAvg](https://github.com/blazefl/blazefl/tree/main/examples/experimental-freethreaded) | Explore high-performance parallel training with a **multi-threaded** FedAvg, leveraging Python 3.13+'s experimental free-threading mode. | 
+| [Step-by-Step Tutorial: DS-FL](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl) | Build a custom distillation-based Federated Learning algorithm from scratch, and understand how to implement your own algorithms on the BlazeFL framework. |
 
 
 ## Robust Reproducibility
@@ -326,8 +326,8 @@ The benchmark was conducted in the following Podman container environment:
 ### Results
 
 <div style="display: flex; justify-content: center; align-items: center;">
-  <img src="https://raw.githubusercontent.com/kitsuyaazuma/blazefl/refs/heads/main/docs/imgs/benchmark_cnn.svg" alt="CNN" width="48%" />
-  <img src="https://raw.githubusercontent.com/kitsuyaazuma/blazefl/refs/heads/main/docs/imgs/benchmark_resnet18.svg" alt="ResNet18" width="48%" />
+  <img src="https://raw.githubusercontent.com/blazefl/blazefl/refs/heads/main/docs/imgs/benchmark_cnn.svg" alt="CNN" width="48%" />
+  <img src="https://raw.githubusercontent.com/blazefl/blazefl/refs/heads/main/docs/imgs/benchmark_resnet18.svg" alt="ResNet18" width="48%" />
 </div>
 <br>
 
@@ -336,6 +336,6 @@ The benchmark results indicate that BlazeFL has competitive performance against 
 
 ## Contributing
 
-We welcome contributions from the community! If you'd like to contribute to this project, please see our [contribution guidelines](https://github.com/kitsuyaazuma/blazefl/blob/main/docs/source/contribute.rst) for more information on how to get started.
+We welcome contributions from the community! If you'd like to contribute to this project, please see our [contribution guidelines](https://github.com/blazefl/blazefl/blob/main/docs/source/contribute.rst) for more information on how to get started.
 
-Please note that this project is governed by our [Code of Conduct](https://github.com/kitsuyaazuma/blazefl/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+Please note that this project is governed by our [Code of Conduct](https://github.com/blazefl/blazefl/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -22,7 +22,7 @@ We gladly accept pull requests! Before submitting a pull request, please ensure 
 Code of Conduct
 ---------------
 
-Please note that this project is governed by our `Code of Conduct <https://github.com/kitsuyaazuma/BlazeFL/blob/main/CODE_OF_CONDUCT.md>`_.
+Please note that this project is governed by our `Code of Conduct <https://github.com/blazefl/blazefl/blob/main/CODE_OF_CONDUCT.md>`_.
 By participating, you are expected to uphold this code. Please report any unacceptable behavior.
 
 Thank you for contributing to our project!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ BlazeFL Documentation
 
 - 🛡️ **Structured and Type-Safe by Design**: By leveraging `dataclasses <https://docs.python.org/3/library/dataclasses.html>`_ and `protocols <https://typing.python.org/en/latest/spec/protocol.html>`_, BlazeFL enables the creation of clear, type-safe, and self-documenting communication packages (``UplinkPackage``, ``DownlinkPackage``). This design enhances code readability, maintainability, and reduces errors in FL workflows.
 
-For a comprehensive overview, including detailed execution modes, benchmarks, and setup examples, please refer to the `README.md <https://github.com/kitsuyaazuma/blazefl/blob/main/README.md>`_ on our GitHub repository.
+For a comprehensive overview, including detailed execution modes, benchmarks, and setup examples, please refer to the `README.md <https://github.com/blazefl/blazefl/blob/main/README.md>`_ on our GitHub repository.
 
 .. toctree::
    :maxdepth: 1

--- a/examples/quickstart-fedavg/README.md
+++ b/examples/quickstart-fedavg/README.md
@@ -9,7 +9,7 @@ Welcome to the quickstart guide for the Federated Averaging (FedAvg [^1]) with B
 First, clone the BlazeFL repository and navigating to the `quickstart-fedavg` directory:
 
 ```bash
-git clone https://github.com/kitsuyaazuma/blazefl.git
+git clone https://github.com/blazefl/blazefl.git
 cd blazefl/examples/quickstart-fedavg
 ```
 

--- a/examples/step-by-step-dsfl/README.md
+++ b/examples/step-by-step-dsfl/README.md
@@ -100,7 +100,7 @@ Meanwhile, `get_dataloader` wraps that dataset in a `DataLoader`.
 This design is flexible enough even for methods like DS-FL, which rely on an open dataset.
 If you don’t need one of these methods, you can simply implement it with `pass`.
 
-You can view the complete source code [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/dataset).
+You can view the complete source code [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/dataset).
 
 ## Implementing a ModelSelector
 
@@ -136,7 +136,7 @@ class DSFLModelSelector(ModelSelector[DSFLModelName]):
 Here, we define model names using `StrEnum` for better type safety. The `select_model` method then takes a `DSFLModelName` and returns the corresponding `nn.Module`.
 You can store useful information (like the number of classes) as attributes in your `ModelSelector`.
 
-The full source code can be found [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/models).
+The full source code can be found [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/models).
 
 ## Defining DownlinkPackage and UplinkPackage
 
@@ -261,7 +261,7 @@ If any of these methods are not needed for your approach, you can simply impleme
 
 In DS-FL, the `global_update` method aggregates the soft labels from clients and distills them into a global model.
 However, you have the flexibility to place any custom operations in these or other methods.
-You can find more details in the [official documentation](https://kitsuyaazuma.github.io/blazefl/generated/blazefl.core.BaseServerHandler.html#blazefl.core.BaseServerHandler).
+You can find more details in the [official documentation](https://blazefl.github.io/blazefl/generated/blazefl.core.BaseServerHandler.html#blazefl.core.BaseServerHandler).
 
 
 ## Implementing a ProcessPoolClientTrainer
@@ -433,7 +433,7 @@ You mainly need to implement:
 By storing shared data on disk instead of passing it directly, you avoid complex shared memory management.
 This design makes it straightforward to enable parallel training.
 
-The complete source code is [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/algorithm/dsfl.py).
+The complete source code is [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/algorithm/dsfl.py).
 
 ## Implementing a Pipeline
 
@@ -480,7 +480,7 @@ This pipeline is almost identical to one you might create for FedAvg or another 
 
 In this snippet, we use TensorBoard via SummaryWriter for logging, but you’re free to use alternatives like [W&B](https://github.com/wandb/wandb).
 
-You can see the full source code [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/main.py).
+You can see the full source code [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/main.py).
 
 ## Running the Simulation
 


### PR DESCRIPTION
## WHAT

This PR updates all hardcoded URLs, repository paths, and links throughout the documentation and examples. All references to the old `kitsuyaazuma/blazefl` path have been changed to the new `blazefl/blazefl` organization path.

## WHY

The repository was recently transferred to the new `blazefl` organization. These changes are necessary to ensure all links are accurate, point to the correct location, and do not rely on GitHub's redirect mechanism.