### PR TITLE
refactor!: remove ipc mode and storage-based communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ graph LR
 
 **Utilizes separate processes to achieve true parallelism and robust resource isolation.**
 
-This mode, corresponding to the `ProcessPoolClientTrainer` class, offers excellent performance. It provides two options for Inter-Process Communication (IPC), configurable via the `ipc_mode` parameter, to suit your needs:
-- **Storage Mode**: Shares parameters via disk, reducing memory usage.
-- **Shared Memory Mode**: Shares parameters directly in shared memory for potentially faster performance.
+This mode, corresponding to the `ProcessPoolClientTrainer` class, offers excellent performance. It utilizes efficient shared memory for Inter-Process Communication (IPC) to minimize overhead when transferring model parameters between processes.
 
 ```mermaid
 graph LR
@@ -86,7 +84,7 @@ graph LR
     end
 
     subgraph "ProcessPoolClientTrainer (e.g. Max Processes = 3)"
-      SHM[("<center>Shared Memory<br>or<br>Storage</center>")]
+      SHM[("<center>Shared Memory</center>")]
       SPJ1@{ shape: f-circ, label: "Junction" }
       subgraph "Process 1"
         SP1[Client 1] --> SP4[Client 4]

--- a/benchmarks/blazefl-case/main.py
+++ b/benchmarks/blazefl-case/main.py
@@ -14,7 +14,6 @@ from blazefl.contrib import (
     FedAvgProcessPoolClientTrainer,
     FedAvgThreadPoolClientTrainer,
 )
-from blazefl.core import IPCMode
 from blazefl.reproducibility import setup_reproducibility
 from dataset import PartitionedCIFAR10
 from models import FedAvgModelName, FedAvgModelSelector
@@ -78,16 +77,13 @@ def main(
     batch_size: int = 50,
     num_parallels: int = 10,
     dataset_root_dir: Path = Path("/tmp/blazefl-case/dataset"),
-    share_dir_base: Path = Path("/tmp/blazefl-case/share"),
     state_dir_base: Path = Path("/tmp/blazefl-case/state"),
     execution_mode: ExecutionMode = EXECUTION_MODE,
-    ipc_mode: IPCMode = IPCMode.SHARED_MEMORY,
 ):
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     dataset_split_dir = dataset_root_dir / timestamp
-    share_dir = share_dir_base / timestamp
     state_dir = state_dir_base / timestamp
 
     device = "cpu"
@@ -144,7 +140,6 @@ def main(
                 model_selector=model_selector,
                 model_name=model_name,
                 dataset=dataset,
-                share_dir=share_dir,
                 state_dir=state_dir,
                 seed=seed,
                 device=device,
@@ -153,7 +148,6 @@ def main(
                 lr=lr,
                 batch_size=batch_size,
                 num_parallels=num_parallels,
-                ipc_mode=ipc_mode,
             )
         case ExecutionMode.MULTI_THREADED:
             assert not sys._is_gil_enabled()

--- a/examples/quickstart-fedavg/main.py
+++ b/examples/quickstart-fedavg/main.py
@@ -21,7 +21,6 @@ from blazefl.contrib import (
     FedAvgProcessPoolClientTrainer,
     FedAvgThreadPoolClientTrainer,
 )
-from blazefl.core import IPCMode
 from blazefl.reproducibility import setup_reproducibility
 
 from dataset import PartitionedCIFAR10
@@ -120,9 +119,6 @@ def main(
     dataset_root_dir: Annotated[
         Path, typer.Option(help="Root directory for the dataset.")
     ] = Path("/tmp/quickstart-fedavg/dataset"),
-    share_dir_base: Annotated[
-        Path, typer.Option(help="Base directory for sharing data between processes.")
-    ] = Path("/tmp/quickstart-fedavg/share"),
     state_dir_base: Annotated[
         Path, typer.Option(help="Directory path for saving data between processes.")
     ] = Path("/tmp/quickstart-fedavg/state"),
@@ -135,13 +131,6 @@ def main(
             )
         ),
     ] = "multi-threaded",
-    ipc_mode: Annotated[
-        IPCMode,
-        typer.Option(
-            help="Inter-process communication mode. 'STORAGE' uses disk for data "
-            "exchange, 'SHARED_MEMORY' uses shared memory for tensor data."
-        ),
-    ] = IPCMode.SHARED_MEMORY,
 ) -> None:
     device = "cpu"
     if torch.cuda.is_available():
@@ -157,7 +146,6 @@ def main(
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     dataset_split_dir = dataset_root_dir / timestamp
-    share_dir = share_dir_base / timestamp
     state_dir = state_dir_base / timestamp
 
     setup_reproducibility(seed)
@@ -208,7 +196,6 @@ def main(
                 model_selector=model_selector,
                 model_name=model_name,
                 dataset=dataset,
-                share_dir=share_dir,
                 state_dir=state_dir,
                 seed=seed,
                 device=device,
@@ -217,7 +204,6 @@ def main(
                 lr=lr,
                 batch_size=batch_size,
                 num_parallels=num_parallels,
-                ipc_mode=ipc_mode,
             )
         case "multi-threaded":
             trainer = FedAvgThreadPoolClientTrainer(

--- a/examples/step-by-step-dsfl/.python-version
+++ b/examples/step-by-step-dsfl/.python-version
@@ -1,1 +1,1 @@
-3.13
+3.14+freethreaded

--- a/examples/step-by-step-dsfl/algorithm/__init__.py
+++ b/examples/step-by-step-dsfl/algorithm/__init__.py
@@ -1,3 +1,3 @@
-from algorithm.dsfl import DSFLBaseServerHandler, DSFLProcessPoolClientTrainer
+from algorithm.dsfl import DSFLBaseServerHandler, DSFLThreadPoolClientTrainer
 
-__all__ = ["DSFLBaseServerHandler", "DSFLProcessPoolClientTrainer"]
+__all__ = ["DSFLBaseServerHandler", "DSFLThreadPoolClientTrainer"]

--- a/examples/step-by-step-dsfl/algorithm/dsfl.py
+++ b/examples/step-by-step-dsfl/algorithm/dsfl.py
@@ -1,21 +1,19 @@
 import threading
 from collections import defaultdict
 from collections.abc import Iterable
+from concurrent.futures import Future, as_completed
 from copy import deepcopy
 from dataclasses import dataclass
-from multiprocessing.pool import ApplyResult
 from pathlib import Path
 
 import torch
-import torch.multiprocessing as mp
 import torch.nn.functional as F
 from blazefl.core import (
     BaseServerHandler,
     FilteredDataset,
-    IPCMode,
-    ProcessPoolClientTrainer,
+    ThreadPoolClientTrainer,
 )
-from blazefl.reproducibility import RNGSuite, create_rng_suite, setup_reproducibility
+from blazefl.reproducibility import RNGSuite, create_rng_suite
 from torch.utils.data import DataLoader, Subset
 from tqdm import tqdm
 
@@ -114,6 +112,7 @@ class DSFLBaseServerHandler(BaseServerHandler[DSFLUplinkPackage, DSFLDownlinkPac
             list[torch.Tensor]
         )
         for soft_labels, indices in zip(soft_labels_list, indices_list, strict=True):
+            assert type(soft_labels) is torch.Tensor and type(indices) is torch.Tensor
             for soft_label, index in zip(soft_labels, indices, strict=True):
                 soft_labels_stack[int(index.item())].append(soft_label)
 
@@ -270,14 +269,13 @@ class DSFLClientState:
     kd_optimizer: dict[str, torch.Tensor] | None
 
 
-class DSFLProcessPoolClientTrainer(
-    ProcessPoolClientTrainer[DSFLUplinkPackage, DSFLDownlinkPackage, DSFLClientConfig]
+class DSFLThreadPoolClientTrainer(
+    ThreadPoolClientTrainer[DSFLUplinkPackage, DSFLDownlinkPackage]
 ):
     def __init__(
         self,
         model_selector: DSFLModelSelector,
         model_name: DSFLModelName,
-        share_dir: Path,
         state_dir: Path,
         dataset: DSFLPartitionedDataset,
         device: str,
@@ -292,8 +290,6 @@ class DSFLProcessPoolClientTrainer(
         num_parallels: int,
     ) -> None:
         self.num_parallels = num_parallels
-        self.share_dir = share_dir
-        self.share_dir.mkdir(parents=True, exist_ok=True)
         self.device = device
         if self.device == "cuda":
             self.device_count = torch.cuda.device_count()
@@ -313,111 +309,95 @@ class DSFLProcessPoolClientTrainer(
         self.device = device
         self.num_clients = num_clients
         self.seed = seed
-        self.ipc_mode = IPCMode(IPCMode.STORAGE)
-        self.manager = mp.Manager()
-        self.stop_event = self.manager.Event()
+        self.stop_event = threading.Event()
 
-        if self.device == "cuda":
-            self.device_count = torch.cuda.device_count()
+        self.client_states: dict[int, DSFLClientState] = {}
 
     def progress_fn(
-        self,
-        it: list[ApplyResult],
-    ) -> Iterable[ApplyResult]:
-        return tqdm(it, desc="Client", leave=False)
+        self, it: list[Future[DSFLUplinkPackage]]
+    ) -> Iterable[Future[DSFLUplinkPackage]]:
+        return tqdm(as_completed(it), total=len(it), desc="Client", leave=False)
 
-    @staticmethod
     def worker(
-        config: DSFLClientConfig | Path,
-        payload: DSFLDownlinkPackage | Path,
+        self,
+        cid: int,
         device: str,
+        payload: DSFLDownlinkPackage,
         stop_event: threading.Event,
-        *,
-        shm_buffer: DSFLUplinkPackage | None = None,
-    ) -> Path:
-        assert isinstance(config, Path) and isinstance(payload, Path)
-        config_path, payload_path = config, payload
-        c = torch.load(config_path, weights_only=False)
-        p = torch.load(payload_path, weights_only=False)
-        assert isinstance(c, DSFLClientConfig) and isinstance(p, DSFLDownlinkPackage)
-
-        setup_reproducibility(c.seed)
-
-        model = c.model_selector.select_model(c.model_name)
-        optimizer = torch.optim.SGD(model.parameters(), lr=c.lr)
+    ) -> DSFLUplinkPackage:
+        model = self.model_selector.select_model(self.model_name)
+        optimizer = torch.optim.SGD(model.parameters(), lr=self.lr)
         kd_optimizer: torch.optim.SGD | None = None
 
-        state: DSFLClientState | None = None
-        if c.state_path.exists():
-            state = torch.load(c.state_path, weights_only=False)
-            assert isinstance(state, DSFLClientState)
+        if cid in self.client_states:
+            state = self.client_states[cid]
             rng_suite = state.random
             model.load_state_dict(state.model)
             optimizer.load_state_dict(state.optimizer)
             if state.kd_optimizer is not None:
-                kd_optimizer = torch.optim.SGD(model.parameters(), lr=c.kd_lr)
+                kd_optimizer = torch.optim.SGD(model.parameters(), lr=self.kd_lr)
                 kd_optimizer.load_state_dict(state.kd_optimizer)
         else:
-            rng_suite = create_rng_suite(c.seed)
+            rng_suite = create_rng_suite(self.seed)
 
         # Distill
-        open_dataset = c.dataset.get_dataset(type_=DSFLPartitionType.OPEN, cid=None)
-        if p.indices is not None and p.soft_labels is not None:
-            global_soft_labels = list(torch.unbind(p.soft_labels, dim=0))
-            global_indices = p.indices.tolist()
+        open_dataset = self.dataset.get_dataset(type_=DSFLPartitionType.OPEN, cid=None)
+        if payload.indices is not None and payload.soft_labels is not None:
+            global_soft_labels = list(torch.unbind(payload.soft_labels, dim=0))
+            global_indices = payload.indices.tolist()
             if kd_optimizer is None:
-                kd_optimizer = torch.optim.SGD(model.parameters(), lr=c.kd_lr)
+                kd_optimizer = torch.optim.SGD(model.parameters(), lr=self.kd_lr)
 
             open_loader = DataLoader(
                 Subset(open_dataset, global_indices),
-                batch_size=c.kd_batch_size,
+                batch_size=self.kd_batch_size,
             )
             DSFLBaseServerHandler.distill(
                 model=model,
                 optimizer=kd_optimizer,
                 open_loader=open_loader,
                 global_soft_labels=global_soft_labels,
-                kd_epochs=c.kd_epochs,
-                kd_batch_size=c.kd_batch_size,
+                kd_epochs=self.kd_epochs,
+                kd_batch_size=self.kd_batch_size,
                 device=device,
                 stop_event=stop_event,
             )
 
         # Train
-        train_loader = c.dataset.get_dataloader(
+        train_loader = self.dataset.get_dataloader(
             type_=DSFLPartitionType.TRAIN,
-            cid=c.cid,
-            batch_size=c.batch_size,
+            cid=cid,
+            batch_size=self.batch_size,
             generator=rng_suite.torch_cpu,
         )
-        DSFLProcessPoolClientTrainer.train(
+        DSFLThreadPoolClientTrainer.train(
             model=model,
             optimizer=optimizer,
             train_loader=train_loader,
             device=device,
-            epochs=c.epochs,
+            epochs=self.epochs,
             stop_event=stop_event,
         )
-        c.dataset.set_dataset(
-            dataset=train_loader.dataset, type_=DSFLPartitionType.TRAIN, cid=c.cid
+        self.dataset.set_dataset(
+            dataset=train_loader.dataset, type_=DSFLPartitionType.TRAIN, cid=cid
         )
 
         # Predict
         open_loader = DataLoader(
-            Subset(open_dataset, p.next_indices.tolist()),
-            batch_size=c.batch_size,
+            Subset(open_dataset, payload.next_indices.tolist()),
+            batch_size=self.batch_size,
         )
-        soft_labels = DSFLProcessPoolClientTrainer.predict(
+        soft_labels = DSFLThreadPoolClientTrainer.predict(
             model=model,
             open_loader=open_loader,
             device=device,
         )
 
         # Evaluate
-        test_loader = c.dataset.get_dataloader(
+        test_loader = self.dataset.get_dataloader(
             type_=DSFLPartitionType.TEST,
-            cid=c.cid,
-            batch_size=c.batch_size,
+            cid=cid,
+            batch_size=self.batch_size,
         )
         loss, acc = DSFLBaseServerHandler.evaulate(
             model=model,
@@ -426,21 +406,20 @@ class DSFLProcessPoolClientTrainer(
         )
 
         package = DSFLUplinkPackage(
-            cid=c.cid,
+            cid=cid,
             soft_labels=soft_labels,
-            indices=p.next_indices,
+            indices=payload.next_indices,
             metadata={"loss": loss, "acc": acc},
         )
 
-        torch.save(package, config_path)
-        state = DSFLClientState(
+        self.client_states[cid] = DSFLClientState(
             random=rng_suite,
             model=model.state_dict(),
             optimizer=optimizer.state_dict(),
             kd_optimizer=kd_optimizer.state_dict() if kd_optimizer else None,
         )
-        torch.save(state, c.state_path)
-        return config_path
+
+        return package
 
     @staticmethod
     def train(
@@ -491,23 +470,6 @@ class DSFLProcessPoolClientTrainer(
 
         soft_labels = torch.cat(soft_labels_list, dim=0)
         return soft_labels.cpu()
-
-    def get_client_config(self, cid: int) -> DSFLClientConfig:
-        data = DSFLClientConfig(
-            model_selector=self.model_selector,
-            model_name=self.model_name,
-            dataset=self.dataset,
-            epochs=self.epochs,
-            batch_size=self.batch_size,
-            lr=self.lr,
-            kd_epochs=self.kd_epochs,
-            kd_batch_size=self.kd_batch_size,
-            kd_lr=self.kd_lr,
-            cid=cid,
-            seed=self.seed,
-            state_path=self.state_dir.joinpath(f"{cid}.pt"),
-        )
-        return data
 
     def uplink_package(self) -> list[DSFLUplinkPackage]:
         package = deepcopy(self.cache)

--- a/examples/step-by-step-dsfl/algorithm/dsfl.py
+++ b/examples/step-by-step-dsfl/algorithm/dsfl.py
@@ -341,7 +341,7 @@ class DSFLThreadPoolClientTrainer(
                     assert kd_optimizer is not None
                     kd_optimizer.load_state_dict(state.kd_optimizer)
             else:
-                rng_suite = create_rng_suite(self.seed)
+                rng_suite = create_rng_suite(self.seed + cid)
 
         # Distill
         open_dataset = self.dataset.get_dataset(type_=DSFLPartitionType.OPEN, cid=None)

--- a/examples/step-by-step-dsfl/main.py
+++ b/examples/step-by-step-dsfl/main.py
@@ -12,12 +12,11 @@ from pathlib import Path
 from typing import Annotated
 
 import torch
-import torch.multiprocessing as mp
 import typer
 import wandb
 from blazefl.reproducibility import setup_reproducibility
 
-from algorithm import DSFLBaseServerHandler, DSFLProcessPoolClientTrainer
+from algorithm import DSFLBaseServerHandler, DSFLThreadPoolClientTrainer
 from dataset import DSFLPartitionedDataset
 from models import DSFLModelName, DSFLModelSelector
 
@@ -26,7 +25,7 @@ class DSFLPipeline:
     def __init__(
         self,
         handler: DSFLBaseServerHandler,
-        trainer: DSFLProcessPoolClientTrainer,
+        trainer: DSFLThreadPoolClientTrainer,
         run: wandb.Run,
     ) -> None:
         self.handler = handler
@@ -102,13 +101,10 @@ def main(
     num_parallels: Annotated[
         int,
         typer.Option(help="Number of parallel processes for training."),
-    ] = 10,
+    ] = 5,
     dataset_root_dir: Annotated[
         Path, typer.Option(help="Root directory for the dataset.")
     ] = Path("/tmp/step-by-step-dsfl/dataset"),
-    share_dir_base: Annotated[
-        Path, typer.Option(help="Base directory for sharing data between processes.")
-    ] = Path("/tmp/step-by-step-dsfl/share"),
     state_dir_base: Annotated[
         Path, typer.Option(help="Directory path for saving data between processes.")
     ] = Path("/tmp/step-by-step-dsfl/state"),
@@ -143,7 +139,6 @@ def main(
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     dataset_split_dir = dataset_root_dir / timestamp
-    share_dir = share_dir_base / timestamp
     state_dir = state_dir_base / timestamp
 
     setup_reproducibility(seed)
@@ -174,11 +169,10 @@ def main(
         sample_ratio=sample_ratio,
         seed=seed,
     )
-    trainer = DSFLProcessPoolClientTrainer(
+    trainer = DSFLThreadPoolClientTrainer(
         model_selector=model_selector,
         model_name=model_name,
         dataset=dataset,
-        share_dir=share_dir,
         state_dir=state_dir,
         seed=seed,
         device=device,
@@ -200,7 +194,4 @@ def main(
 
 
 if __name__ == "__main__":
-    # NOTE: To use CUDA with multiprocessing, you must use the 'spawn' start method
-    mp.set_start_method("spawn")
-
     typer.run(main)

--- a/examples/step-by-step-dsfl/main.py
+++ b/examples/step-by-step-dsfl/main.py
@@ -101,7 +101,7 @@ def main(
     num_parallels: Annotated[
         int,
         typer.Option(help="Number of parallel processes for training."),
-    ] = 5,
+    ] = 10,
     dataset_root_dir: Annotated[
         Path, typer.Option(help="Root directory for the dataset.")
     ] = Path("/tmp/step-by-step-dsfl/dataset"),

--- a/examples/step-by-step-dsfl/pyproject.toml
+++ b/examples/step-by-step-dsfl/pyproject.toml
@@ -3,7 +3,7 @@ name = "step-by-step-dsfl"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 dependencies = [
     "blazefl[reproducibility]",
     "torchvision>=0.24.0",

--- a/src/blazefl/core/__init__.py
+++ b/src/blazefl/core/__init__.py
@@ -7,7 +7,6 @@ including client trainers, model selectors, partitioned datasets, and server han
 
 from blazefl.core.client_trainer import (
     BaseClientTrainer,
-    IPCMode,
     ProcessPoolClientTrainer,
     ThreadPoolClientTrainer,
 )
@@ -27,7 +26,6 @@ __all__ = [
     "FilteredDataset",
     "ProcessPoolClientTrainer",
     "ThreadPoolClientTrainer",
-    "IPCMode",
     "ModelSelector",
     "PartitionedDataset",
     "BaseServerHandler",

--- a/src/blazefl/core/__init__.pyi
+++ b/src/blazefl/core/__init__.pyi
@@ -1,7 +1,7 @@
-from blazefl.core.client_trainer import BaseClientTrainer as BaseClientTrainer, IPCMode as IPCMode, ProcessPoolClientTrainer as ProcessPoolClientTrainer, ThreadPoolClientTrainer as ThreadPoolClientTrainer
+from blazefl.core.client_trainer import BaseClientTrainer as BaseClientTrainer, ProcessPoolClientTrainer as ProcessPoolClientTrainer, ThreadPoolClientTrainer as ThreadPoolClientTrainer
 from blazefl.core.model_selector import ModelSelector as ModelSelector
 from blazefl.core.partitioned_dataset import FilteredDataset as FilteredDataset, PartitionedDataset as PartitionedDataset
 from blazefl.core.server_handler import BaseServerHandler as BaseServerHandler
 from blazefl.core.utils import SHMHandle as SHMHandle, deserialize_model as deserialize_model, process_tensors_in_object as process_tensors_in_object, reconstruct_from_shared_memory as reconstruct_from_shared_memory, serialize_model as serialize_model
 
-__all__ = ['BaseClientTrainer', 'FilteredDataset', 'ProcessPoolClientTrainer', 'ThreadPoolClientTrainer', 'IPCMode', 'ModelSelector', 'PartitionedDataset', 'BaseServerHandler', 'serialize_model', 'deserialize_model', 'process_tensors_in_object', 'reconstruct_from_shared_memory', 'SHMHandle']
+__all__ = ['BaseClientTrainer', 'FilteredDataset', 'ProcessPoolClientTrainer', 'ThreadPoolClientTrainer', 'ModelSelector', 'PartitionedDataset', 'BaseServerHandler', 'serialize_model', 'deserialize_model', 'process_tensors_in_object', 'reconstruct_from_shared_memory', 'SHMHandle']

--- a/src/blazefl/core/client_trainer.py
+++ b/src/blazefl/core/client_trainer.py
@@ -2,12 +2,8 @@ import signal
 import threading
 from collections.abc import Iterable
 from concurrent.futures import Future, ThreadPoolExecutor
-from enum import StrEnum
 from multiprocessing.pool import ApplyResult
-from pathlib import Path
 from typing import Protocol, TypeVar
-
-import torch
 
 from blazefl.core.utils import process_tensors_in_object, reconstruct_from_shared_memory
 
@@ -53,13 +49,6 @@ class BaseClientTrainer(Protocol[UplinkPackage, DownlinkPackage]):
 ClientConfig = TypeVar("ClientConfig")
 
 
-class IPCMode(StrEnum):
-    """Inter-process communication modes for data exchange between processes."""
-
-    STORAGE = "STORAGE"
-    SHARED_MEMORY = "SHARED_MEMORY"
-
-
 class ProcessPoolClientTrainer(
     BaseClientTrainer[UplinkPackage, DownlinkPackage],
     Protocol[UplinkPackage, DownlinkPackage, ClientConfig],
@@ -76,20 +65,15 @@ class ProcessPoolClientTrainer(
         device (str): The primary device to use for computation (e.g., "cpu", "cuda").
         device_count (int): The number of available CUDA devices, if `device` is "cuda".
         cache (list[UplinkPackage]): Cache to store uplink packages from clients.
-        ipc_mode (IPCMode): Inter-process communication mode. IPCMode.STORAGE uses disk
-            for data exchange, IPCMode.SHARED_MEMORY uses shared memory for tensor data.
-            Defaults to IPCMode.STORAGE.
 
     Raises:
         NotImplementedError: If the abstract methods are not implemented in a subclass.
     """
 
     num_parallels: int
-    share_dir: Path
     device: str
     device_count: int
     cache: list[UplinkPackage]
-    ipc_mode: IPCMode = IPCMode.STORAGE
     stop_event: threading.Event
 
     def progress_fn(
@@ -136,13 +120,13 @@ class ProcessPoolClientTrainer(
 
     @staticmethod
     def worker(
-        config: ClientConfig | Path,
-        payload: DownlinkPackage | Path,
+        config: ClientConfig,
+        payload: DownlinkPackage,
         device: str,
         stop_event: threading.Event,
         *,
         shm_buffer: UplinkPackage | None = None,
-    ) -> UplinkPackage | Path:
+    ) -> UplinkPackage:
         """
         Process a single client's training task.
 
@@ -151,21 +135,18 @@ class ProcessPoolClientTrainer(
         the client-specific operations, and returning the result.
 
         Args:
-            config (ClientConfig | Path):
-                The client's configuration data, or a path to a file containing
-                the configuration if `ipc_mode` is "storage".
-            payload (DownlinkPackage | Path):
-                The downlink payload from the server, or a path to a file
-                containing the payload if `ipc_mode` is "storage".
+            config (ClientConfig):
+                The client's configuration data.
+            payload (DownlinkPackage):
+                The downlink payload from the server
             device (str): Device to use for processing (e.g., "cpu", "cuda:0").
             stop_event (threading.Event): Event to signal stopping the worker.
             shm_buffer (UplinkPackage | None):
                 Optional shared memory buffer for the uplink package.
 
         Returns:
-            UplinkPackage | Path:
-                The uplink package containing the client's results, or a path
-                to a file containing the package if `ipc_mode` is "storage".
+            UplinkPackage:
+                The uplink package containing the client's results.
         """
         ...
 
@@ -188,17 +169,12 @@ class ProcessPoolClientTrainer(
         """
         import torch.multiprocessing as mp
 
-        payload_path = Path()
         shm_buffers = {}
-        if self.ipc_mode == IPCMode.STORAGE:
-            payload_path = self.share_dir.joinpath("payload.pkl")
-            torch.save(payload, payload_path)
-        else:  # shared_memory
-            process_tensors_in_object(payload, mode="move")
-            for cid in cid_list:
-                buffer = self.prepare_uplink_package_buffer()
-                process_tensors_in_object(buffer, mode="move")
-                shm_buffers[cid] = buffer
+        process_tensors_in_object(payload, mode="move")
+        for cid in cid_list:
+            buffer = self.prepare_uplink_package_buffer()
+            process_tensors_in_object(buffer, mode="move")
+            shm_buffers[cid] = buffer
 
         self.stop_event.clear()
         pool = mp.Pool(
@@ -211,40 +187,25 @@ class ProcessPoolClientTrainer(
             for cid in cid_list:
                 config = self.get_client_config(cid)
                 device = self.get_client_device(cid)
-                if self.ipc_mode == IPCMode.STORAGE:
-                    config_path = self.share_dir.joinpath(f"{cid}.pkl")
-                    torch.save(config, config_path)
-                    jobs.append(
-                        pool.apply_async(
-                            self.worker,
-                            (config_path, payload_path, device, self.stop_event),
+                jobs.append(
+                    pool.apply_async(
+                        self.worker,
+                        (
+                            config,
+                            payload,
+                            device,
+                            self.stop_event,
                         ),
-                    )
-                else:  # shared_memory
-                    jobs.append(
-                        pool.apply_async(
-                            self.worker,
-                            (
-                                config,
-                                payload,
-                                device,
-                                self.stop_event,
-                            ),
-                            kwds={
-                                "shm_buffer": shm_buffers.get(cid),
-                            },
-                        ),
-                        # )
-                    )
+                        kwds={
+                            "shm_buffer": shm_buffers.get(cid),
+                        },
+                    ),
+                )
 
             for i, job in enumerate(self.progress_fn(jobs)):
                 result = job.get()
-                if self.ipc_mode == IPCMode.STORAGE:
-                    assert isinstance(result, Path)
-                    package = torch.load(result, weights_only=False)
-                else:  # shared_memory
-                    cid = cid_list[i]
-                    package = reconstruct_from_shared_memory(result, shm_buffers[cid])
+                cid = cid_list[i]
+                package = reconstruct_from_shared_memory(result, shm_buffers[cid])
                 self.cache.append(package)
         finally:
             self.stop_event.set()

--- a/src/blazefl/core/client_trainer.py
+++ b/src/blazefl/core/client_trainer.py
@@ -61,7 +61,6 @@ class ProcessPoolClientTrainer(
 
     Attributes:
         num_parallels (int): Number of parallel processes to use for client training.
-        share_dir (Path): Directory path for sharing data between processes.
         device (str): The primary device to use for computation (e.g., "cpu", "cuda").
         device_count (int): The number of available CUDA devices, if `device` is "cuda".
         cache (list[UplinkPackage]): Cache to store uplink packages from clients.

--- a/src/blazefl/core/client_trainer.pyi
+++ b/src/blazefl/core/client_trainer.pyi
@@ -2,9 +2,7 @@ import threading
 from blazefl.core.utils import process_tensors_in_object as process_tensors_in_object, reconstruct_from_shared_memory as reconstruct_from_shared_memory
 from collections.abc import Iterable
 from concurrent.futures import Future as Future
-from enum import StrEnum
 from multiprocessing.pool import ApplyResult as ApplyResult
-from pathlib import Path
 from typing import Protocol, TypeVar
 
 UplinkPackage = TypeVar('UplinkPackage')
@@ -15,23 +13,17 @@ class BaseClientTrainer(Protocol[UplinkPackage, DownlinkPackage]):
     def local_process(self, payload: DownlinkPackage, cid_list: list[int]) -> None: ...
 ClientConfig = TypeVar('ClientConfig')
 
-class IPCMode(StrEnum):
-    STORAGE = "STORAGE"
-    SHARED_MEMORY = "SHARED_MEMORY"
-
 class ProcessPoolClientTrainer(BaseClientTrainer[UplinkPackage, DownlinkPackage], Protocol[UplinkPackage, DownlinkPackage, ClientConfig]):
     num_parallels: int
-    share_dir: Path
     device: str
     device_count: int
     cache: list[UplinkPackage]
-    ipc_mode: IPCMode
     stop_event: threading.Event
     def progress_fn(self, it: list[ApplyResult]) -> Iterable[ApplyResult]: ...
     def get_client_config(self, cid: int) -> ClientConfig: ...
     def get_client_device(self, cid: int) -> str: ...
     @staticmethod
-    def worker(config: ClientConfig | Path, payload: DownlinkPackage | Path, device: str, stop_event: threading.Event, *, shm_buffer: UplinkPackage | None = None) -> UplinkPackage | Path: ...
+    def worker(config: ClientConfig, payload: DownlinkPackage, device: str, stop_event: threading.Event, *, shm_buffer: UplinkPackage | None = None) -> UplinkPackage: ...
     def prepare_uplink_package_buffer(self) -> UplinkPackage: ...
     def local_process(self, payload: DownlinkPackage, cid_list: list[int]) -> None: ...
 

--- a/tests/test_contrib/test_fedavg.py
+++ b/tests/test_contrib/test_fedavg.py
@@ -10,7 +10,6 @@ import torch
 import torch.multiprocessing as mp
 from torch.utils.data import DataLoader, Dataset
 
-from blazefl.core.client_trainer import IPCMode
 from src.blazefl.contrib.fedavg import (
     FedAvgBaseClientTrainer,
     FedAvgBaseServerHandler,
@@ -100,12 +99,6 @@ def device():
 
 
 @pytest.fixture
-def tmp_share_dir(tmp_path):
-    share_dir = tmp_path / "share"
-    return share_dir
-
-
-@pytest.fixture
 def tmp_state_dir(tmp_path):
     state_dir = tmp_path / "state"
     return state_dir
@@ -171,9 +164,8 @@ def _run_process_pool_trainer(
         trainer.local_process(downlink, cids)
 
 
-@pytest.mark.parametrize("ipc_mode", [IPCMode.STORAGE, IPCMode.SHARED_MEMORY])
 def test_base_handler_and_process_pool_trainer_integration(
-    model_selector, partitioned_dataset, device, tmp_share_dir, tmp_state_dir, ipc_mode
+    model_selector, partitioned_dataset, device, tmp_state_dir
 ):
     mp.set_start_method("spawn", force=True)
 
@@ -202,7 +194,6 @@ def test_base_handler_and_process_pool_trainer_integration(
     trainer = FedAvgProcessPoolClientTrainer(
         model_selector=model_selector,
         model_name=model_name,
-        share_dir=tmp_share_dir,
         state_dir=tmp_state_dir,
         dataset=partitioned_dataset,
         device=device,
@@ -212,7 +203,6 @@ def test_base_handler_and_process_pool_trainer_integration(
         lr=lr,
         seed=seed,
         num_parallels=num_parallels,
-        ipc_mode=ipc_mode,
     )
 
     for round_ in range(1, global_round + 1):
@@ -232,7 +222,7 @@ def test_base_handler_and_process_pool_trainer_integration(
 
 
 def test_base_handler_and_process_pool_trainer_integration_keyboard_interrupt(
-    model_selector, partitioned_dataset, device, tmp_share_dir, tmp_state_dir
+    model_selector, partitioned_dataset, device, tmp_state_dir
 ):
     mp.set_start_method("spawn", force=True)
 
@@ -261,7 +251,6 @@ def test_base_handler_and_process_pool_trainer_integration_keyboard_interrupt(
     trainer_init_args = {
         "model_selector": model_selector,
         "model_name": model_name,
-        "share_dir": tmp_share_dir,
         "state_dir": tmp_state_dir,
         "dataset": partitioned_dataset,
         "device": device,
@@ -271,7 +260,6 @@ def test_base_handler_and_process_pool_trainer_integration_keyboard_interrupt(
         "lr": lr,
         "seed": seed,
         "num_parallels": num_parallels,
-        "ipc_mode": "storage",
     }
 
     cids = server.sample_clients()

--- a/tests/test_core/test_client_trainer.py
+++ b/tests/test_core/test_client_trainer.py
@@ -1,12 +1,10 @@
 import threading
 from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 import torch
 import torch.multiprocessing as mp
 
-from blazefl.core.client_trainer import IPCMode
 from blazefl.core.utils import SHMHandle
 from src.blazefl.core import ProcessPoolClientTrainer
 
@@ -34,18 +32,13 @@ class DummyProcessPoolClientTrainer(
     def __init__(
         self,
         num_parallels: int,
-        share_dir: Path,
         device: str,
-        ipc_mode: IPCMode,
     ):
         self.num_parallels = num_parallels
-        self.share_dir = share_dir
-        self.share_dir.mkdir(parents=True, exist_ok=True)
         self.device = device
         if self.device == "cuda":
             self.device_count = torch.cuda.device_count()
         self.cache: list[UplinkPackage] = []
-        self.ipc_mode = ipc_mode
         self.manager = mp.Manager()
         self.stop_event = self.manager.Event()
 
@@ -60,75 +53,33 @@ class DummyProcessPoolClientTrainer(
 
     @staticmethod
     def worker(
-        config: ClientConfig | Path,
-        payload: DownlinkPackage | Path,
+        config: ClientConfig,
+        payload: DownlinkPackage,
         device: str,
         stop_event: threading.Event,
         *,
         shm_buffer: UplinkPackage | None = None,
-    ) -> UplinkPackage | Path:
-        def _storage_worker(
-            config_path: Path,
-            payload_path: Path,
-            device: str,
-            stop_event: threading.Event,
-        ) -> Path:
-            config = torch.load(config_path, weights_only=False)
-            assert isinstance(config, ClientConfig)
-            payload = torch.load(payload_path, weights_only=False)
-            dummy_uplink_package = _shared_memory_worker(
-                config=config,
-                payload=payload,
-                device=device,
-                stop_event=stop_event,
-            )
-            torch.save(dummy_uplink_package, config_path)
-            return config_path
+    ) -> UplinkPackage:
+        _ = stop_event
+        _ = device
+        dummy_uplink_package = UplinkPackage(
+            cid=config.cid,
+            tensor=torch.rand(1),
+            message=payload.message + "<client_to_server>",
+        )
 
-        def _shared_memory_worker(
-            config: ClientConfig,
-            payload: DownlinkPackage,
-            device: str,
-            stop_event: threading.Event,
-        ) -> UplinkPackage:
-            _ = stop_event
-            _ = device
-            dummy_uplink_package = UplinkPackage(
-                cid=config.cid,
-                tensor=torch.rand(1),
-                message=payload.message + "<client_to_server>",
-            )
-            return dummy_uplink_package
-
-        if isinstance(config, Path) and isinstance(payload, Path):
-            return _storage_worker(config, payload, device, stop_event)
-        elif isinstance(config, ClientConfig) and isinstance(payload, DownlinkPackage):
-            package = _shared_memory_worker(config, payload, device, stop_event)
-            assert shm_buffer is not None
-            shm_buffer.tensor = package.tensor
-            package.tensor = SHMHandle()
-            return package
-        else:
-            raise TypeError(
-                "Invalid types for config and payload."
-                "Expected ClientConfig and DownlinkPackage or Path."
-            )
+        assert shm_buffer is not None
+        shm_buffer.tensor = dummy_uplink_package.tensor
+        dummy_uplink_package.tensor = SHMHandle()
+        return dummy_uplink_package
 
 
 @pytest.mark.parametrize("num_parallels", [1, 2, 4])
 @pytest.mark.parametrize("cid_list", [[], [42], [0, 1, 2]])
-@pytest.mark.parametrize("ipc_mode", ["storage", "shared_memory"])
-def test_process_pool_client_trainer(
-    tmp_path: Path,
-    num_parallels: int,
-    cid_list: list[int],
-    ipc_mode: IPCMode,
-) -> None:
+def test_process_pool_client_trainer(num_parallels: int, cid_list: list[int]) -> None:
     trainer = DummyProcessPoolClientTrainer(
         num_parallels=num_parallels,
-        share_dir=tmp_path,
         device="cpu",
-        ipc_mode=ipc_mode,
     )
 
     dummy_payload = DownlinkPackage(message="<server_to_client>")


### PR DESCRIPTION
## WHAT

* Removes the `IPCMode` enum and the file-system based data exchange mechanism (`IPCMode.STORAGE`) from `ProcessPoolClientTrainer`.
* Removes `share_dir` and `ipc_mode` arguments from `ProcessPoolClientTrainer`, `FedAvgProcessPoolClientTrainer`, and their associated tests.
* Updates the `step-by-step-dsfl` example to use `ThreadPoolClientTrainer` targeting Python 3.14+ (freethreaded) instead of multiprocessing.

## WHY

The `IPCMode.STORAGE` option added significant complexity to the `ProcessPoolClientTrainer` implementation with little practical benefit over the shared memory approach. Removing it simplifies the architecture and maintenance of the core training logic.