### PR TITLE
chore: v3.0.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "blazefl"
-version = "3.0.0a1"
+version = "3.0.0b1"
 description = "A blazing-fast, minimalist, and researcher-friendly simulation framework for Federated Learning."
 readme = "README.md"
 authors = [
     { name = "kitsuyaazuma", email = "kitsuyaazuma@gmail.com" }
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
 

--- a/src/blazefl/reproducibility/snapshot.py
+++ b/src/blazefl/reproducibility/snapshot.py
@@ -56,7 +56,7 @@ class RandomStateSnapshot:
     torch_cuda: torch.Tensor | None
 
     @classmethod
-    def capture(cls) -> "RandomStateSnapshot":
+    def capture(cls) -> RandomStateSnapshot:
         """
         Captures the current global random state.
 
@@ -81,7 +81,7 @@ class RandomStateSnapshot:
         return snapshot
 
     @staticmethod
-    def restore(snapshot: "RandomStateSnapshot") -> None:
+    def restore(snapshot: RandomStateSnapshot) -> None:
         """
         Restores the global random state from a snapshot object.
 

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "blazefl"
-version = "3.0.0a1"
+version = "3.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "torch" },


### PR DESCRIPTION
## WHAT
This PR marks the Beta 1 release by bumping the version to `3.0.0b1` and updating the lock files.

## WHY
Moving from alpha to beta as the core API stabilizes and quality improvements are integrated.