### PR TITLE
fix: align examples and benchmarks with the current v3 API

### DIFF
--- a/benchmarks/blazefl-case/main.py
+++ b/benchmarks/blazefl-case/main.py
@@ -33,7 +33,7 @@ class FedAvgBenchmarkPipeline:
 
     def main(self):
         start_time = time.perf_counter()
-        while not self.handler.if_stop():
+        while not self.handler.is_stopped():
             round_ = self.handler.round
             # server side
             sampled_clients = self.handler.sample_clients()

--- a/benchmarks/blazefl-case/uv.lock
+++ b/benchmarks/blazefl-case/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "blazefl"
-version = "3.0.0a1"
+version = "3.0.0"
 source = { editable = "../../" }
 dependencies = [
     { name = "torch" },

--- a/benchmarks/main.py
+++ b/benchmarks/main.py
@@ -117,8 +117,10 @@ def main(
     model_name: Literal["CNN", "RESNET18", "RESNET50", "RESNET101"] = "CNN",
 ) -> None:
     logging.info("Starting benchmark...")
-    # cpu_count = os.cpu_count() or 1
-    cpu_count = len(os.sched_getaffinity(0)) or 1
+    try:
+        cpu_count = len(os.sched_getaffinity(0))
+    except AttributeError:
+        cpu_count = os.cpu_count() or 1
     gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
 
     num_parallels: list[int] = [2**i for i in range(int(math.log2(cpu_count) + 1))]

--- a/examples/step-by-step-dsfl/README.md
+++ b/examples/step-by-step-dsfl/README.md
@@ -271,7 +271,7 @@ class DSFLBaseServerHandler(BaseServerHandler[DSFLUplinkPackage, DSFLDownlinkPac
 The `BaseServerHandler` class requires five core methods to be implemented:
 
 - `sample_clients`
-- `if_stop`
+- `is_stopped`
 - `load`
 - `global_update`
 - `downlink_package`
@@ -387,7 +387,7 @@ class DSFLThreadPoolClientTrainer(
             cid=cid,
             batch_size=self.batch_size,
         )
-        loss, acc = DSFLBaseServerHandler.evaulate(
+        loss, acc = DSFLBaseServerHandler.evaluate(
             model=model,
             test_loader=test_loader,
             device=device,

--- a/examples/step-by-step-dsfl/algorithm/dsfl.py
+++ b/examples/step-by-step-dsfl/algorithm/dsfl.py
@@ -186,7 +186,7 @@ class DSFLBaseServerHandler(BaseServerHandler[DSFLUplinkPackage, DSFLDownlinkPac
         return
 
     @staticmethod
-    def evaulate(
+    def evaluate(
         model: torch.nn.Module, test_loader: DataLoader, device: str
     ) -> tuple[float, float]:
         model.to(device)
@@ -218,7 +218,7 @@ class DSFLBaseServerHandler(BaseServerHandler[DSFLUplinkPackage, DSFLDownlinkPac
         return avg_loss, avg_acc
 
     def get_summary(self) -> dict[str, float]:
-        server_loss, server_acc = DSFLBaseServerHandler.evaulate(
+        server_loss, server_acc = DSFLBaseServerHandler.evaluate(
             self.model,
             self.dataset.get_dataloader(
                 type_=DSFLPartitionType.TEST,
@@ -401,7 +401,7 @@ class DSFLThreadPoolClientTrainer(
             cid=cid,
             batch_size=self.batch_size,
         )
-        loss, acc = DSFLBaseServerHandler.evaulate(
+        loss, acc = DSFLBaseServerHandler.evaluate(
             model=model,
             test_loader=test_loader,
             device=device,


### PR DESCRIPTION
## WHAT

This PR updates examples and benchmark scripts to match the current BlazeFL v3 API and runtime behavior.

- replace the outdated `if_stop()` call with `is_stopped()` in the BlazeFL benchmark case
- rename DS-FL example evaluation helpers from `evaulate` to `evaluate`
- sync the step-by-step DS-FL README with the current server handler API
- update `benchmarks/blazefl-case/uv.lock` to reference BlazeFL `3.0.0`
- add a fallback from `os.sched_getaffinity(0)` to `os.cpu_count()` in `benchmarks/main.py` for environments where affinity APIs are unavailable

## WHY

Some example and benchmark code still referenced older BlazeFL APIs, which caused runtime failures such as:

- `AttributeError: 'FedAvgBaseServerHandler' object has no attribute 'if_stop'`

This PR brings the surrounding examples, docs, and benchmark utilities back in sync with the current release.