### PR TITLE
fix: reduce flower-case FAB size and stream benchmark logs

### DIFF
--- a/benchmarks/flower-case/.gitignore
+++ b/benchmarks/flower-case/.gitignore
@@ -1,1 +1,8 @@
+wandb
+.venv/
+.ruff_cache/
+__pycache__/
+apps/
+local-superlink/
+source
 config.toml

--- a/benchmarks/flower-case/README.md
+++ b/benchmarks/flower-case/README.md
@@ -14,5 +14,5 @@ uv sync
 ## Usage
 
 ```bash
-RAY_TMPDIR=/tmp/flower-case FLWR_HOME=$(pwd) uv run flwr run .
+RAY_TMPDIR=/tmp/flower-case FLWR_HOME=$(pwd) uv run flwr run . --stream
 ```

--- a/benchmarks/main.py
+++ b/benchmarks/main.py
@@ -183,7 +183,7 @@ def main(
             "export RAY_TMPDIR=/tmp/flower-case && "
             "FLWR_HOME=$(pwd) "
             "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0 "
-            "uv run flwr run . local "
+            "uv run flwr run . local --stream "
             f"--run-config 'model-name=\"{model_name}\"' "
             "&& rm -rf ${RAY_TMPDIR} "
             "&& cd .."


### PR DESCRIPTION
## WHAT

- exclude local artifacts from `benchmarks/flower-case` FAB builds
- add `--stream` to Flower benchmark commands and documentation
- ensure benchmark logs are emitted during local runs so results can be measured reliably

## WHY

Running the benchmark could fail because local artifacts were included in the FAB build:

`FAB size exceeds maximum allowed size of 10,485,760 bytes`

Also, the benchmark relies on runtime logs for measurement. Since `--stream` is disabled by default, local runs do not emit the required logs unless it is explicitly enabled.